### PR TITLE
Add information about new line at the end of file

### DIFF
--- a/crontab.c
+++ b/crontab.c
@@ -609,6 +609,8 @@ edit_cmd() {
 "# at 5 a.m every week with:\n"
 "# 0 5 * * 1 tar -zcf /var/backups/home.tgz /home/\n"
 "# \n"
+"# This file needs to end with an empty line\n"
+"# \n"
 "# For more information see the manual pages of crontab(5) and cron(8)\n" 
 "# \n"
 "# m h  dom mon dow   command\n" );


### PR DESCRIPTION
To have one less confusion
(https://askubuntu.com/questions/23009/why-crontab-scripts-are-not-working)
 and make linux more user-friendly, I propose to add this small info.